### PR TITLE
Added optional side walls to the topography 

### DIFF
--- a/oggm_3dviz/tools/viz.py
+++ b/oggm_3dviz/tools/viz.py
@@ -27,6 +27,7 @@ class Glacier3DViz:
         add_mesh_topo_args: dict | None = None,
         add_mesh_ice_thick_args: dict | None = None,
         use_texture: bool = False,
+        show_topo_side_walls: bool = False,
         texture_args: dict | None = None,
         text_time_args: dict | None = None,
         light_args: dict | None = None,
@@ -73,6 +74,9 @@ class Glacier3DViz:
             plotter, see pyvista.Plotter.add_mesh
         use_texture: bool
             if True, a background texture is applied on the topography
+        show_topo_side_walls: bool
+            if True, the edges of the topography are set to the minimum elevation
+            of the map, so that the map looks more like a solid.
         texture_args: dict | None
             additional arguments for the texture, see texture.get_topo_texture
         text_time_args: dict | None
@@ -116,6 +120,13 @@ class Glacier3DViz:
                     {self.time: 0})
             else:
                 self.da_topo = self.dataset[self.topo_bedrock]
+
+        if show_topo_side_walls:
+            min_elevation = np.min(self.da_topo)
+            self.da_topo[0, :] = min_elevation
+            self.da_topo[-1, :] = min_elevation
+            self.da_topo[:, 0] = min_elevation
+            self.da_topo[:, -1] = min_elevation
 
         # ignore ice thicknesses equal to 0
         self.da_glacier_thick = xr.where(


### PR DESCRIPTION
The edges of the bedrock topography are set to the minimum elevation of the map if the option "show_topo_side_walls" is true.
The map appears more solid. 
![Screenshot from 2024-11-05 16-15-38](https://github.com/user-attachments/assets/9941e034-5ab0-4f0d-962f-ddcca8035391)
